### PR TITLE
Can 'run' on subdirectories.

### DIFF
--- a/src/Main.hs
+++ b/src/Main.hs
@@ -56,7 +56,7 @@ findDefault = do
     findDefault' pr = do
         cfp <- fromMaybe (error "No cabal file found") <$>
             (find ((== ".cabal") . takeExtension) <$> getDirectoryContents pr)
-        getPackageDescription cfp >>= getDefaultExecutable
+        getPackageDescription (pr </> cfp) >>= getDefaultExecutable
           where
             getPackageDescription p = parsePackageDescription <$> readFile p
             getDefaultExecutable (ParseFailed _) =


### PR DESCRIPTION
cfp returned from getDirectoryContents is relative to pr. To prefix pr
to cfp is necessary to command 'run' on subdirectories other than root.