### PR TITLE
Adapt new Cabal types back to Strings

### DIFF
--- a/src/Main.hs
+++ b/src/Main.hs
@@ -16,6 +16,7 @@ import           Data.Maybe
 import           Data.Time
 import           Distribution.PackageDescription
 import           Distribution.PackageDescription.Parse
+import           Distribution.Types.UnqualComponentName
 import           System.Console.ANSI
 #ifndef OS_Win32
 import           System.Console.Questioner
@@ -72,7 +73,7 @@ findDefault = do
                 error "Failed to parse cabal file"
             getDefaultExecutable (ParseOk _ gpd) = case condExecutables gpd of
                 [] -> error "No executable found"
-                ((d, _):_) -> return d
+                ((d, _):_) -> return (unUnqualComponentName d)
 
 getExecutables :: IO [String]
 getExecutables = do
@@ -88,7 +89,7 @@ getExecutables = do
         error "Failed to parse cabal file"
     getExecutables (ParseOk _ gpd) = case condExecutables gpd of
         [] -> error "No executables found"
-        ds -> map fst ds
+        ds -> map (unUnqualComponentName . fst) ds
 
 getCabalProjectRootCurrent :: IO (Maybe FilePath)
 getCabalProjectRootCurrent = flip catchIOError (const (return Nothing)) $

--- a/stack-run.cabal
+++ b/stack-run.cabal
@@ -28,8 +28,8 @@ executable stack-run
                      , async
                      , base >=4 && <5
                      , bytestring >= 0.10
-                     , conduit > 1.1 && < 1.3
-                     , conduit-extra >= 1.1 && < 1.2
+                     , conduit > 1.1 && < 1.4
+                     , conduit-extra >= 1.1 && < 1.4
                      , directory
                      , filepath
                      , time >= 1.5.0.1

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-8.13
+resolver: lts-11.16
 packages:
 - '.'
 flags: {}


### PR DESCRIPTION
Bump resolver, relax upper bounds, and insert `unnqualComponentName` function calls get code compiling again.

This isn't elegant or anything, but it builds and appears to work correctly.

Closes #17, Closes #12, might close #10.

AfC