### PR TITLE
language extension OverlappingInstances is deprecated

### DIFF
--- a/unix/System/Console/Questioner.hs
+++ b/unix/System/Console/Questioner.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE FlexibleInstances     #-}
-{-# LANGUAGE LambdaCase            #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE OverlappingInstances  #-}
+
 module System.Console.Questioner
     (
       Question(..)


### PR DESCRIPTION
remove `OverlappingInstances` declare from Questioner.hs